### PR TITLE
Ability of unauthenticated user to create tickets

### DIFF
--- a/app/Events/EndUserTicket.php
+++ b/app/Events/EndUserTicket.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+use \App\Models\Ticket;
+use \App\Models\TicketView;
+
+class EndUserTicket implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    private TicketView $ticket_view;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(private Ticket $ticket, private ?string $message = null)
+    {
+        $this->ticket_view = TicketView::find($ticket->id)->forUser();
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn()
+    {
+        return new Channel('register.' . $this->ticket->token);
+    }
+
+    public function broadcastWith()
+    {
+        return [
+            'message' => $this->message ?? 'Your ticket has been closed.',
+            'ticket' => $this->ticket_view
+        ];
+    }
+}

--- a/app/Events/RegisterNewTicket.php
+++ b/app/Events/RegisterNewTicket.php
@@ -34,7 +34,7 @@ class RegisterNewTicket implements ShouldBroadcastNow
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('register.' . $this->ticket->user_id);
+        return new PrivateChannel('register.' . $this->ticket->token);
     }
 
     public function broadcastWith()

--- a/app/Events/UpdateDisplayAboutTicket.php
+++ b/app/Events/UpdateDisplayAboutTicket.php
@@ -25,11 +25,6 @@ class UpdateDisplayAboutTicket implements ShouldBroadcastNow
         return new PrivateChannel('display');
     }
 
-    public function broadcastAs()
-    {
-        return 'UpdateDisplayAboutTicket';
-    }
-
     public function broadcastWith()
     {
         return [

--- a/app/Events/UpdateUserAboutHisTicket.php
+++ b/app/Events/UpdateUserAboutHisTicket.php
@@ -34,7 +34,7 @@ class UpdateUserAboutHisTicket implements ShouldBroadcastNow
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('register.' . $this->ticket->token);
+        return new Channel('register.' . $this->ticket->token);
     }
 
     public function broadcastWith()

--- a/app/Events/UpdateUserAboutHisTicket.php
+++ b/app/Events/UpdateUserAboutHisTicket.php
@@ -34,7 +34,7 @@ class UpdateUserAboutHisTicket implements ShouldBroadcastNow
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('register.' . $this->ticket->user_id);
+        return new PrivateChannel('register.' . $this->ticket->token);
     }
 
     public function broadcastWith()

--- a/app/Http/Controllers/CoordinatorController.php
+++ b/app/Http/Controllers/CoordinatorController.php
@@ -2,12 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\View\View;
 use Illuminate\Http\Request;
-use App\Models\Error;
 use App\Models\Color;
-
-use App\Events\UpdateDisplayAboutTicket;
-use App\Events\UpdateUserAboutHisTicket;
 
 use App\Models\Ticket;
 use App\Models\TicketView;
@@ -17,7 +14,7 @@ use App\Models\Workstation;
 
 class CoordinatorController extends Controller
 {
-    public function index()
+    public function index(Request $request): View
     {
         $color = new Color();
         $tickets = TicketView::all();
@@ -42,108 +39,10 @@ class CoordinatorController extends Controller
 
         return view('coordinator.coordinator')->with(compact('color', 'tickets', 'statuses', 'destinations'))
 
-        // todo: usunąć poniższe, lepiej to robić przez compact.
-        // można wtedy łatwiej wyjąć dane javascriptem poprzez @json($statuses);
-        ->with($variables);
+            // todo: usunąć poniższe, lepiej to robić przez compact.
+            // można wtedy łatwiej wyjąć dane javascriptem poprzez @json($statuses);
+            ->with($variables);
     }
 
-    // todo: przerzucić funkcje związane z ticketem do osobnego kontrolera TicketsController
-    public function move(Request $request, int $ticket_id, ?string $workstation_id, int $status_id = null)
-    {
-        // check if specified ticket exists
-        $ticket = Ticket::find($ticket_id);
-        if ($ticket === null) {
-            $error = new Error(title: 'Ticket not found', http: 404);
-            return $error->toHTTPresponse();
-        }
-
-        // check if status_id is provided via web route
-        if ($status_id !== null) {
-
-            // check if status_id is valid
-            if (Status::find($status_id) === null) {
-                $error = new Error(title: 'Provided status does not exist', http: 404);
-                return $error->toHTTPresponse();
-            }
-
-            // if provided status means end of ticket, redirect to end method
-            if ($status_id == Status::END) {
-                return redirect()->to("/end/{$ticket_id}");
-            }
-        } else {
-            $handled_error = 'No status provided, defaulting to status ' . Status::IN;
-            $status_id = Status::IN;
-        }
-
-        // try to update workstation
-        $error = $ticket->updateWorkstation($workstation_id);
-        if ($error !== null) {
-            return $error->toHTTPresponse();
-        }
-
-        // if workstation_id is provided, try to update status
-        if ($workstation_id != null) {
-            // try to update status
-            $error = $ticket->updateStatus($status_id);
-            if ($error !== null) {
-                return $error->toHTTPresponse();
-            }
-        } else {
-            // workstation_id is not provided, set status to WAITING
-            // if workstation_id is null, but status is anything other that WAITING, user would not know where to go
-            $error = $ticket->updateStatus(Status::WAITING);
-            if ($error !== null) {
-                return $error->toHTTPresponse();
-            }
-            $handled_error = 'Null value provided on workstation. Clearing workstation and moving user to status ' . Status::WAITING;
-        }
-
-        $ticket->save();
-
-        // update user that his ticket has been changed
-        broadcast(new UpdateUserAboutHisTicket($ticket));
-
-        // update display about changes made in ticket
-        broadcast(new UpdateDisplayAboutTicket($ticket));
-
-        // for debugging purposes, return whole summary of ticket
-        if(env('APP_DEBUG')) {
-            return response()->json(['message' => $ticket->summary() ], 200);
-        }
-        
-        return response()->json(['message' => $handled_error ?? 'Success' ], 200);
-    }
-
-    public function end(int $ticket_id)
-    {
-        // check if specified ticket exists
-        $ticket = Ticket::find($ticket_id);
-        if ($ticket === null) {
-            $error = new Error(title: 'Ticket not found', http: 404);
-            return $error->toHTTPresponse();
-        }
-
-
-        // try to update status
-        $error = $ticket->updateStatus(Status::END);
-        if ($error !== null) {
-            return $error->toHTTPresponse();
-        }
-
-        // update user that his ticket has been changed
-        broadcast(new UpdateUserAboutHisTicket($ticket));
-
-        // update display about changes made in ticket
-        broadcast(new UpdateDisplayAboutTicket($ticket));
-
-        // try to end ticket, and if that fails, return error
-        $error = $ticket->end();
-        if ($error !== null) {
-            return $error->toHTTPresponse();
-        }
-
-        // todo: remove token from cookie and session from user
-
-        return response()->json(['message' => "Success"], 200);
-    }
+    // jeżeli chcesz coś zmienić lub podejrzeć w przepływie to przeniosłem to do kontrollera TicketController
 }

--- a/app/Http/Controllers/CoordinatorController.php
+++ b/app/Http/Controllers/CoordinatorController.php
@@ -142,6 +142,8 @@ class CoordinatorController extends Controller
             return $error->toHTTPresponse();
         }
 
+        // todo: remove token from cookie and session from user
+
         return response()->json(['message' => "Success"], 200);
     }
 }

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Cookie;
+
+use App\Models\Error;
+use App\Events\UpdateUserAboutHisTicket;
+use App\Events\UpdateDisplayAboutTicket;
+
+use App\Models\Status;
+use App\Models\Destination;
+use App\Models\Ticket;
+
+
+class TicketController extends Controller
+{
+    public function register(Request $request, $destination_id)
+    {
+        // check if specified destination exists
+        if (Destination::find($destination_id) === null) {
+            $error = new Error(title: 'Destination not found', http: 404);
+            return $error->toHTTPresponse();
+        }
+
+        // for debugging purposes, enable multiple tickets registration
+        if (!env('APP_DEBUG')) {
+            // get token from cookie within request
+            $token = $request->cookie('ticket_token');
+
+            // check if token was found in cookie
+            if ($token) {
+                // If user sends custom token in cookie, Laravel won't decipher it, therefore reject it
+                session(['ticket_token' => $token]);
+            } elseif (session()->has('ticket_token')) {
+                // User may have deleted the cookie, but still have the session
+                $token = session('ticket_token');
+                Cookie::queue('ticket_token', $token);
+            }
+
+            // if token is set, that means user already has ticket
+            if (isset($token)) {
+                //todo: somehow update the status of user's ticket (he may be already in the middle of the process)
+                return response()->json([
+                    'message' => 'You already have a ticket registered',
+                    'channel' => $token
+                ], 200);
+            }
+        }
+
+        
+
+        // create new ticket
+        $ticket = Ticket::create([
+            'destination_id' => $destination_id,
+            'token' => Str::uuid(),
+        ]);
+
+        // update display about new registered ticket
+        broadcast(new UpdateDisplayAboutTicket($ticket));
+
+        // Store ticket token in cookie and session
+        //* Ticket's token is used for "light authentication" and listening on websocket channel
+        Cookie::queue('ticket_token', $ticket->token);
+        session(['ticket_token' => $ticket->token]);
+
+        // Return response with ticket token as channel to listen on 
+        return response()->json([
+            'message' => 'Ticket registered',
+            'channel' => $ticket->token
+        ], 201);
+    }
+
+    public function move(Request $request, int $ticket_id, ?string $workstation_id, int $status_id = null)
+    {
+        // check if specified ticket exists
+        $ticket = Ticket::find($ticket_id);
+        if ($ticket === null) {
+            $error = new Error(title: 'Ticket not found', http: 404);
+            return $error->toHTTPresponse();
+        }
+
+        // check if status_id is provided via web route
+        if ($status_id !== null) {
+
+            // check if status_id is valid
+            if (Status::find($status_id) === null) {
+                $error = new Error(title: 'Provided status does not exist', http: 404);
+                return $error->toHTTPresponse();
+            }
+
+            // if provided status means end of ticket, redirect to end method
+            if ($status_id == Status::END) {
+                return redirect()->to("/end/{$ticket_id}");
+            }
+        } else {
+            $handled_error = 'No status provided, defaulting to status ' . Status::IN;
+            $status_id = Status::IN;
+        }
+
+        // try to update workstation
+        $error = $ticket->updateWorkstation($workstation_id);
+        if ($error !== null) {
+            return $error->toHTTPresponse();
+        }
+
+        // if workstation_id is provided, try to update status
+        if ($workstation_id != null) {
+            // try to update status
+            $error = $ticket->updateStatus($status_id);
+            if ($error !== null) {
+                return $error->toHTTPresponse();
+            }
+        } else {
+            // workstation_id is not provided, set status to WAITING
+            // if workstation_id is null, but status is anything other that WAITING, user would not know where to go
+            $error = $ticket->updateStatus(Status::WAITING);
+            if ($error !== null) {
+                return $error->toHTTPresponse();
+            }
+            $handled_error = 'Null value provided on workstation. Clearing workstation and moving user to status ' . Status::WAITING;
+        }
+
+        $ticket->save();
+
+        // update user that his ticket has been changed
+        broadcast(new UpdateUserAboutHisTicket($ticket));
+
+        // update display about changes made in ticket
+        broadcast(new UpdateDisplayAboutTicket($ticket));
+
+        // for debugging purposes, return whole summary of ticket
+        if(env('APP_DEBUG')) {
+            return response()->json(['message' => $ticket->summary() ], 200);
+        }
+        
+        return response()->json(['message' => $handled_error ?? 'Success' ], 200);
+    }
+
+    public function end(int $ticket_id)
+    {
+        // check if specified ticket exists
+        $ticket = Ticket::find($ticket_id);
+        if ($ticket === null) {
+            $error = new Error(title: 'Ticket not found', http: 404);
+            return $error->toHTTPresponse();
+        }
+
+
+        // try to update status
+        $error = $ticket->updateStatus(Status::END);
+        if ($error !== null) {
+            return $error->toHTTPresponse();
+        }
+
+        // update user that his ticket has been changed
+        broadcast(new UpdateUserAboutHisTicket($ticket));
+
+        // update display about changes made in ticket
+        broadcast(new UpdateDisplayAboutTicket($ticket));
+
+        // try to end ticket, and if that fails, return error
+        $error = $ticket->end();
+        if ($error !== null) {
+            return $error->toHTTPresponse();
+        }
+
+        // todo: remove token from cookie and session from user
+
+        return response()->json(['message' => "Success"], 200);
+    }
+}

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -31,13 +31,20 @@ class TicketController extends Controller
         if (!env('APP_DEBUG')) {
             $token = $this->getUserToken($request);
 
-            // todo: handle exception when user somehow still has valid token, but ticket is nowhere to be found
             if ($token !== null) {
-                //todo: somehow update the status of user's ticket (he may be already in the middle of the process)
-                return response()->json([
-                    'message' => 'You already have a ticket registered',
-                    'channel' => $token
-                ], 200);
+                if (Ticket::where('token', $token)->exists()) {
+                    
+                    //todo: somehow update the status of user's ticket (he may be already in the middle of the process)
+
+                    return response()->json([
+                        'message' => 'You already have a ticket registered',
+                        'channel' => $token
+                    ], 200);
+                } else {
+                    // somehow user sent valid token, but ticket is not found
+                    // clear user's storage and continue creating new ticket
+                    $this->clearStorage($request);
+                }
             }
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -4,14 +4,8 @@ namespace App\Http\Controllers;
 
 use Illuminate\View\View;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Cookie;
-use App\Models\Error;
 use App\Models\Color;
 
-use App\Events\UpdateUserAboutHisTicket;
-
-use App\Models\Ticket;
 use App\Models\Destination;
 
 class UserController extends Controller
@@ -22,57 +16,5 @@ class UserController extends Controller
         $destinations = Destination::all();
 
         return view('user.user')->with(compact('color', 'destinations'));
-    }
-
-    // todo: move it to seperate TicketController
-    public function register(Request $request, $destination_id)
-    {
-        // check if specified destination exists
-        if (Destination::find($destination_id) === null) {
-            $error = new Error(title: 'Destination not found', http: 404);
-            return $error->toHTTPresponse();
-        }
-
-        // get token from cookie within request
-        $token = $request->cookie('ticket_token');
-
-        // check if token was found in cookie
-        if ($token) {
-            // If user sends custom token in cookie, Laravel won't decipher it, therefore reject it
-            session(['ticket_token' => $token]);
-        } elseif (session()->has('ticket_token')) {
-            // User may have deleted the cookie, but still have the session
-            $token = session('ticket_token');
-            Cookie::queue('ticket_token', $token);
-        }
-
-        // if token is set, that means user already has ticket
-        if (isset($token)) {
-            return response()->json([
-                'message' => 'You already have a ticket registered',
-                'channel' => $token
-            ], 200);
-        }
-
-        // create new ticket
-        $ticket = Ticket::create([
-            'destination_id' => $destination_id,
-            'token' => Str::uuid(),
-        ]);
-
-        //! broken functionality (for now)
-        // // update display about new registered ticket
-        // broadcast(new UpdateDisplayAboutTicket($ticket));
-
-        // Store ticket token in cookie and session
-        //* Ticket's token is used for "light authentication" and listening on websocket channel
-        Cookie::queue('ticket_token', $ticket->token);
-        session(['ticket_token' => $ticket->token]);
-
-        // Return response with ticket token as channel to listen on 
-        return response()->json([
-            'message' => 'Ticket registered',
-            'channel' => $ticket->token
-        ], 201);
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\View\View;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use App\Models\Error;
 use App\Models\Color;
 
@@ -13,11 +15,9 @@ use App\Events\UpdateDisplayAboutTicket;
 use App\Models\Ticket;
 use App\Models\Destination;
 
-use function Symfony\Component\String\b;
-
 class UserController extends Controller
 {
-    public function index()
+    public function index(): View
     {
         $variables["color"] = new Color();
         $variables["destinations"] = Destination::all();
@@ -25,6 +25,7 @@ class UserController extends Controller
         return view('user.user')->with($variables);
     }
 
+    // todo: move it to seperate TicketController
     public function register(Request $request, $destination_id)
     {
         // check if specified destination exists
@@ -33,7 +34,8 @@ class UserController extends Controller
             return $error->toHTTPresponse();
         }
 
-        // check if user can have multiple tickets registered
+        // todo: change it to seek the token, cut off from auth
+        //* check if user can have multiple tickets registered
         if (!env('MULTIPLE_TICKETS')) {
             if (auth()->user()->hasTickets()) {
                 // find user ticket
@@ -51,6 +53,7 @@ class UserController extends Controller
         // create new ticket
         $ticket = Ticket::create([
             'destination_id' => $destination_id,
+            'token' => Str::uuid(),
         ]);
 
         // broadcast event to user his ticket has been registered

--- a/app/Http/Middleware/CheckRole.php
+++ b/app/Http/Middleware/CheckRole.php
@@ -15,8 +15,13 @@ class CheckRole
      *
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
-    public function handle(Request $request, Closure $next, string $role): Response
+    public function handle(Request $request, Closure $next, int $role): Response
     {
+        // if this is a user space, move forward // todo: maybe more elegant? or handle tokens?
+        if ($role === 1) {
+            return $next($request);
+        }
+
         // get loggged user
         $user = Auth::user();
 

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -143,7 +143,7 @@ class Ticket extends Model
     {
         $message = [
             "Ticket id: {$this->id}.",
-            "User {$this->user->name} going to destination id {$this->destination->id}.",
+            "User {$this->user?->name} going to destination id {$this->destination->id}.",
             "Currently set to workstation {$this->workstation?->id} with status {$this->status->id}."
         ];
 

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -21,7 +21,7 @@ class Ticket extends Model
     public $incrementing = true;
     protected $keyType = 'int'; 
 
-    protected $fillable = ['destination_id'];
+    protected $fillable = ['destination_id', 'token'];
 
     /**
      * Boot function to add ticket_nr to the ticket
@@ -51,6 +51,7 @@ class Ticket extends Model
         });
     }
 
+    // relationships
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/app/Models/TicketView.php
+++ b/app/Models/TicketView.php
@@ -13,7 +13,7 @@ class TicketView extends Model
     public $timestamps = false;
 
     // necessary for function forUser
-    protected $fillable = ['user', 'destination', 'status', 'status_id', 'workstation'];
+    protected $fillable = ['user', 'destination', 'status', 'workstation'];
 
     /**
      * Translate status, destination and workstation on retrieved
@@ -49,7 +49,6 @@ class TicketView extends Model
             'user' => $this->user,
             'destination' => $this->destination,
             'status' => $this->status,
-            'status_id' => $this->status_id,
             'workstation' => $this->workstation,
         ]);
     }

--- a/database/migrations/2024_11_16_214835_add_token_column_to_tickets.php
+++ b/database/migrations/2024_11_16_214835_add_token_column_to_tickets.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->uuid('token')->unique();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->dropUnique(['token']);
+            $table->dropColumn('token');
+        });
+    }
+};

--- a/database/migrations/2024_11_16_221654_make_user_id_nullable_in_tickets_table.php
+++ b/database/migrations/2024_11_16_221654_make_user_id_nullable_in_tickets_table.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // SQLite doesn't automaticcly update views when changing source tables
+        DB::statement('DROP VIEW IF EXISTS tickets_view');
+
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->nullable()->change();
+        });
+
+        DB::statement("
+            CREATE VIEW tickets_view AS
+            SELECT 
+                tickets.id,
+                users.name AS user,
+                tickets.ticket_nr,
+                destinations.name AS destination,
+                tickets.destination_id,
+                statuses.name AS status,
+                tickets.status_id,
+                workstations.name AS workstation,
+                tickets.workstation_id
+            FROM tickets
+            LEFT JOIN users ON tickets.user_id = users.id
+            LEFT JOIN destinations ON tickets.destination_id = destinations.id
+            LEFT JOIN statuses ON tickets.status_id = statuses.id
+            LEFT JOIN workstations ON tickets.workstation_id = workstations.id
+        ");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement('DROP VIEW IF EXISTS tickets_view');
+
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->nullable(false)->change();
+        });
+
+        DB::statement("
+            CREATE VIEW tickets_view AS
+            SELECT 
+                tickets.id,
+                users.name AS user,
+                tickets.ticket_nr,
+                destinations.name AS destination,
+                tickets.destination_id,
+                statuses.name AS status,
+                tickets.status_id,
+                workstations.name AS workstation,
+                tickets.workstation_id
+            FROM tickets
+            LEFT JOIN users ON tickets.user_id = users.id
+            LEFT JOIN destinations ON tickets.destination_id = destinations.id
+            LEFT JOIN statuses ON tickets.status_id = statuses.id
+            LEFT JOIN workstations ON tickets.workstation_id = workstations.id
+        ");
+    }
+};

--- a/resources/views/display/display.blade.php
+++ b/resources/views/display/display.blade.php
@@ -78,7 +78,7 @@ class PipeQ {
         }
 
         // fill the card with ticket data
-        ticket_card.querySelector('h5').textContent = ticket.user;
+        ticket_card.querySelector('h5').textContent = ticket.ticket_nr;
         ticket_card.querySelector('p').textContent = ticket.status;
         ticket_card.querySelector('h6').textContent = ticket.workstation;
 

--- a/resources/views/user/user.blade.php
+++ b/resources/views/user/user.blade.php
@@ -74,39 +74,38 @@
 
 class PipeQ {
     constructor() {
-        // todo: change channel to use something other than used id
-        const channel = Echo.private(`register.{{ Auth::user()?->id }}`);
-        this.register = channel;
-        this._listen();
+        //
     }
 
     _listen() {
-        this.register.listen('RegisterNewTicket', function(e) {
-            console.log(e);
-        })
-
         this.register.listen('UpdateUserAboutHisTicket', function(e) {
-            console.log(e); toggleOverlay2(e.ticket); showLoading();
-            
+            console.log(e);
+            toggleOverlay2(e.ticket);
+            showLoading();
         })
-
     }
 
     _register(destination_id) {
         axios.post(`/register/${destination_id}`)
             .then(response => {
-                @if(env('APP_DEBUG'))
-                    console.log(response);
-                @endif
+                // Listen for response with channel name
+                console.log(response);
+
+                // if channel name is received, subscribe to it
+                if (response.data.channel) {
+                    this.register = Echo.private(`register.${response.data.channel}`);
+                    this._listen();
+                } else {
+                    console.error('Channel name not received');
+                }
             })
             .catch(error => {
-
+                // if error message is handled by the server, display it, otherwise display generic error
                 if(error.response.data.error) {
                     console.error(error.response.data.error);
                 } else {
                     console.error(error);
                 }
-                
             });
     }
 }

--- a/resources/views/user/user.blade.php
+++ b/resources/views/user/user.blade.php
@@ -90,28 +90,15 @@ class PipeQ {
         })
 
         this.register.listen('EndUserTicket', (e) => {
-            console.log('Your ticket has ended', e);
+            console.log('Your ticket has ended');
 
-
-            // todo: clear user session and cookie
-
-
-            //* none of the below works
-            // // if ticket has ended, clear cookie and session
-            // console.log(e.ticket.status_id)
-            // if (e.ticket.status_id == {!! App\Models\Status::END !!}) {
-            //     console.log('siema')
-            //     this._clearStorage();
-            // }
-            // console.log(e);
-            // toggleOverlay2(e.ticket);
-            // showLoading();
-            // // if ticket has ended, clear cookie and session
-            // console.log(e.ticket.status_id)
-            // if (e.ticket.status_id == {!! App\Models\Status::END !!}) {
-            //     console.log('siema')
-            //     this._clearStorage();
-            // }
+            axios.post('{!! route("_clear"); !!}')
+                .then(response => {
+                    console.log(response.data.message);
+                })
+                .catch(error => {
+                    console.log(error);
+                });
         })
     }
 
@@ -119,7 +106,7 @@ class PipeQ {
         axios.post(`/register/${destination_id}`)
             .then(response => {
                 // Listen for response with channel name
-                console.log(response);
+                console.log(response.data.message + ' token: ' + response.data.channel);
 
                 // if channel name is received, subscribe to it
                 if (response.data.channel) {

--- a/resources/views/user/user.blade.php
+++ b/resources/views/user/user.blade.php
@@ -100,7 +100,13 @@ class PipeQ {
                 @endif
             })
             .catch(error => {
-                console.error(error.response.data.error);
+
+                if(error.response.data.error) {
+                    console.error(error.response.data.error);
+                } else {
+                    console.error(error);
+                }
+                
             });
     }
 }

--- a/resources/views/user/user.blade.php
+++ b/resources/views/user/user.blade.php
@@ -93,7 +93,7 @@ class PipeQ {
 
                 // if channel name is received, subscribe to it
                 if (response.data.channel) {
-                    this.register = Echo.private(`register.${response.data.channel}`);
+                    this.register = Echo.channel(`register.${response.data.channel}`);
                     this._listen();
                 } else {
                     console.error('Channel name not received');

--- a/resources/views/user/user.blade.php
+++ b/resources/views/user/user.blade.php
@@ -6,6 +6,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.8.1/font/bootstrap-icons.min.css" rel="stylesheet">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 </head>
 <body>
 
@@ -74,14 +75,43 @@
 
 class PipeQ {
     constructor() {
-        //
+        // todo: automatically join channel if user has token
+        
+        //* none of the below works
+        // $.removeCookie('ticket_token');
+        // document.cookie = "ticket_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
     }
 
     _listen() {
-        this.register.listen('UpdateUserAboutHisTicket', function(e) {
+        this.register.listen('UpdateUserAboutHisTicket', (e) => {
             console.log(e);
             toggleOverlay2(e.ticket);
             showLoading();
+        })
+
+        this.register.listen('EndUserTicket', (e) => {
+            console.log('Your ticket has ended', e);
+
+
+            // todo: clear user session and cookie
+
+
+            //* none of the below works
+            // // if ticket has ended, clear cookie and session
+            // console.log(e.ticket.status_id)
+            // if (e.ticket.status_id == {!! App\Models\Status::END !!}) {
+            //     console.log('siema')
+            //     this._clearStorage();
+            // }
+            // console.log(e);
+            // toggleOverlay2(e.ticket);
+            // showLoading();
+            // // if ticket has ended, clear cookie and session
+            // console.log(e.ticket.status_id)
+            // if (e.ticket.status_id == {!! App\Models\Status::END !!}) {
+            //     console.log('siema')
+            //     this._clearStorage();
+            // }
         })
     }
 

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -1,18 +1,12 @@
 <?php
 
-use App\Models\User;
 use Illuminate\Support\Facades\Broadcast;
 
-// Domyślna konfiguracja kanału stworzona przez framework
-// Broadcast::channel('App.Models.User.{id}', function ($user, $id) {
-//     return (int) $user->id === (int) $id;
-// });
-
-Broadcast::channel('register.{user_id}', function ($user, int $user_id) {
-    return (int) $user->id === (int) $user_id;
+Broadcast::channel('register.{ticket_token}', function () {
+    return true;
 });
 
-// todo: dodanie autoryzację tylko do koordynatorów i przeglądarek z odpowiednim certyfikatem
+// todo: dodanie autoryzacji przeglądarek z odpowiednim certyfikatem
 Broadcast::channel('display', function () {
     return true;
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Auth;
 use App\Models\Role;
 use App\Http\Controllers\LanguageController;
 
+use App\Http\Controllers\TicketController;
+
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\DisplayController;
 use App\Http\Controllers\CoordinatorController;
@@ -60,6 +62,6 @@ Route::get("/administrator", [AdministratorController::class, 'index'])
 
 // API for client -> server communication
 // todo: przenieśc do routes/api.php
-Route::any("/register/{destination_id}", [UserController::class, 'register'])->name('_register');
-Route::any("/move/{ticket_id}/{workstation_id?}/{status_id?}", [CoordinatorController::class, 'move'])->middleware(['auth', 'verified'])->name('_move');
-Route::any("/end/{ticket_id}", [CoordinatorController::class, 'end'])->middleware(['auth', 'verified'])->name('_end');
+Route::any("/register/{destination_id}", [TicketController::class, 'register'])->name('_register');
+Route::any("/move/{ticket_id}/{workstation_id?}/{status_id?}", [TicketController::class, 'move'])->middleware(['auth', 'verified'])->name('_move');
+Route::any("/end/{ticket_id}", [TicketController::class, 'end'])->middleware(['auth', 'verified'])->name('_end');

--- a/routes/web.php
+++ b/routes/web.php
@@ -64,3 +64,4 @@ Route::get("/administrator", [AdministratorController::class, 'index'])
 Route::any("/register/{destination_id}", [TicketController::class, 'register'])->name('_register');
 Route::any("/move/{ticket_id}/{workstation_id?}/{status_id?}", [TicketController::class, 'move'])->middleware(['auth', 'verified'])->name('_move');
 Route::any("/end/{ticket_id}", [TicketController::class, 'end'])->middleware(['auth', 'verified'])->name('_end');
+Route::any("/clear", [TicketController::class, 'clear'])->name('_clear');

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,7 +61,10 @@ Route::get("/administrator", [AdministratorController::class, 'index'])
 
 // API for client -> server communication
 // todo: przenieśc do routes/api.php
+// todo: change any to post
 Route::any("/register/{destination_id}", [TicketController::class, 'register'])->name('_register');
+Route::any("/endByUser/{ticket_token?}", [TicketController::class, 'endByUser'])->name('_endByUser');
+Route::any("/clearStorage", [TicketController::class, 'clearStorage'])->name('_clear');
+
 Route::any("/move/{ticket_id}/{workstation_id?}/{status_id?}", [TicketController::class, 'move'])->middleware(['auth', 'verified'])->name('_move');
 Route::any("/end/{ticket_id}", [TicketController::class, 'end'])->middleware(['auth', 'verified'])->name('_end');
-Route::any("/clear", [TicketController::class, 'clear'])->name('_clear');

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,10 +3,8 @@
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Auth;
-use App\Http\Controllers\LanguageController;
-
 use App\Models\Role;
-use App\Http\Middleware\CheckRole;
+use App\Http\Controllers\LanguageController;
 
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\DisplayController;
@@ -30,6 +28,7 @@ Route::get('/language/{locale}', [LanguageController::class, 'set'])->name('loca
 
 Route::get("/", [UserController::class, 'index'])
     ->middleware([
+        'auth',
         'role:'.Role::USER
     ])
     ->name('user');

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,7 +30,6 @@ Route::get('/language/{locale}', [LanguageController::class, 'set'])->name('loca
 
 Route::get("/", [UserController::class, 'index'])
     ->middleware([
-        'auth',
         'role:'.Role::USER
     ])
     ->name('user');

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,7 +30,6 @@ Route::get('/language/{locale}', [LanguageController::class, 'set'])->name('loca
 
 Route::get("/", [UserController::class, 'index'])
     ->middleware([
-        'auth',
         'role:'.Role::USER
     ])
     ->name('user');
@@ -62,6 +61,6 @@ Route::get("/administrator", [AdministratorController::class, 'index'])
 
 // API for client -> server communication
 // todo: przenieśc do routes/api.php
-Route::any("/register/{destination_id}", [UserController::class, 'register'])->middleware(['auth', 'verified'])->name('_register');
+Route::any("/register/{destination_id}", [UserController::class, 'register'])->name('_register');
 Route::any("/move/{ticket_id}/{workstation_id?}/{status_id?}", [CoordinatorController::class, 'move'])->middleware(['auth', 'verified'])->name('_move');
 Route::any("/end/{ticket_id}", [CoordinatorController::class, 'end'])->middleware(['auth', 'verified'])->name('_end');


### PR DESCRIPTION
**Users don't have to be unauthenticated to create their tickets.**
There are cases, where user's don't have their accounts in database. Changed the code so it is based around tokens which are given away for users in a form of a cookie. If user somehow looses his cookie, program will try to recover the token from session. This way, when user reloads the page, information about his registered ticket won't be lost. After the ticket ends, token in both cookie and session are deleted.

Because users are not longer unauthenticated, but can be individually identified, WebSocket channel had to be changed to public, but to keep information private, individual channels are identified by token.